### PR TITLE
Added triggers to create universe resource block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -250,6 +250,10 @@ locals {
 }
 
 resource "null_resource" "create_yugabyte_universe" {
+  # Define the trigger condition to run the resource block
+  triggers = {
+    cluster_instance_ids = "${join(",", aws_instance.yugabyte_nodes.*.id)}" 
+  }
 
   # Execute after the nodes are provisioned and the software installed.
   depends_on = ["aws_instance.yugabyte_nodes"]


### PR DESCRIPTION
Added triggers block to the create universe resource. This would make the block run when you do updates to terraform.

- Tested by launching a default terraform
- Increased the number of nodes and validated it was added
- Deleted the number of nodes and validated it was deleted.

PS: this still doesn't support change config yet.

https://github.com/YugaByte/yugabyte-db/issues/2098