### PR TITLE
Remove old interpolation syntax

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: "tf-aws: Build and Test"
 
 on:
   push:

--- a/.github/workflows/update-submodule.yaml
+++ b/.github/workflows/update-submodule.yaml
@@ -1,4 +1,4 @@
-name: "Update utilities submodule"
+name: "tf-aws: Update utilities submodule"
 
 on:
   repository_dispatch:

--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -1,4 +1,4 @@
-name: "Update YugabyteDB version"
+name: "tf-aws: Update YugabyteDB version"
 on:
   repository_dispatch:
     types:

--- a/README.md
+++ b/README.md
@@ -1,45 +1,74 @@
 # terraform-aws-yugabyte
-A Terraform module to deploy and run YugaByte on AWS.
+A Terraform module to deploy and run YugabyteDB on Amazon Web Services (AWS).
 
-## Config
+## Configuration
 
-Save the following content to a terraform configuration file yb.tf
+* To download and install Terraform, follow the steps given [here](https://www.terraform.io/downloads.html).
 
-```
-module "yugabyte-db-cluster" {
-  source = "github.com/YugaByte/terraform-aws-yugabyte"
+* Export the required credentials in current shell,
+  ```sh
+  export AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE"
+  export AWS_SECRET_ACCESS_KEY="wJal/…/bPxRfiCYEXAMPLEKEY"
+  ```
 
-  # The name of the cluster to be created.
-  cluster_name = "yb-test"
+  For other authentication methods, take a look at the [AWS
+  Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication)
+  documentation.
 
-  # Specify an existing AWS key pair
-  # Both the name and the path to the corresponding private key file
-  ssh_keypair = "SSH_KEYPAIR_HERE"     
-  ssh_private_key = "SSH_KEY_PATH_HERE"
+* Create a new directory along with a terraform file,
+  ```sh
+  $ mkdir yugabytedb-deploy && cd yugabytedb-deploy
+  $ touch deploy.tf
+  ```
 
-  # The existing vpc and subnet ids where the nodes should be spawned.
-  region_name = "AWS REGION"
-  vpc_id = "VPC_ID_HERE"
+* Open `deploy.tf` in your favorite editor and add following content
+  to it,
+  ```hcl
+  module "yugabyte-db-cluster" {
+	# The source module used for creating clusters on AWS.
+	source = "github.com/yugabyte/terraform-aws-yugabyte"
 
-  # Cluster data and metadata will be placed in separate AZs to ensure availability during single AZ failure if 3 AZs are specified.
-  # To tolerate single AZ failure, the AZ count should be equal to RF.
-  availability_zones = ["AZ1", "AZ2", "AZ3"]
-  subnet_ids = ["SUBNET_AZ1", SUBNET_AZ2", "SUBNET_AZ3"]
+	# The name of the cluster to be created.
+	cluster_name = "yb-test"
 
-  # Replication factor.
-  replication_factor = "3"
+	# Specify an existing AWS key pair
+	# Both the name and the path to the corresponding private key file
+	ssh_keypair = "SSH_KEYPAIR_NAME"
+	ssh_private_key = "PATH_TO_SSH_PRIVATE_KEY_FILE"
 
-  # The number of nodes in the cluster, this cannot be lower than the replication factor.
-  num_instances = "3"
-}
-```
+	# The existing vpc and subnet ids where the nodes should be spawned.
+	region_name = "AWS REGION"
+	vpc_id = "VPC_ID_HERE"
+
+	# Cluster data and metadata will be placed in separate AZs to ensure availability during single AZ failure if 3 AZs are specified.
+	# To tolerate single AZ failure, the AZ count should be equal to RF.
+	availability_zones = ["AZ1", "AZ2", "AZ3"]
+	subnet_ids = ["SUBNET_AZ1", SUBNET_AZ2", "SUBNET_AZ3"]
+
+	# Replication factor.
+	replication_factor = "3"
+
+	# The number of nodes in the cluster, this cannot be lower than the replication factor.
+	num_instances = "3"
+  }
+
+  output "outputs" {
+	value = module.yugabyte-db-cluster
+  }
+  ```
 
 ## Usage
 
-Init terraform first if you have not already done so.
+Initialize Terraform first if you have not already done so.
 
 ```
 $ terraform init
+```
+
+To check what changes are going to happen in the environment run the following,
+
+```
+$ terraform plan
 ```
 
 Now run the following to create the instances and bring up the cluster.
@@ -48,13 +77,13 @@ Now run the following to create the instances and bring up the cluster.
 $ terraform apply
 ```
 
-Once the cluster is created, you can go to the URL `http://<node ip or dns name>:7000` to view the UI. You can find the node's ip or dns by running the following:
+Once the cluster is created, you can go to the URL `http://<node ip or dns name>:7000` to view the YB-Master UI. You can find the node's IP address or DNS by running the following:
 
 ```
-terraform state show aws_instance.yugabyte_nodes[0]
+$ terraform state show module.yugabyte-db-cluster.aws_instance.yugabyte_nodes[0]
 ```
 
-You can access the cluster UI by going to any of the following URLs.
+You can access the YB-Master UI by going to public IP address of any of the instances at port `7000`. The IP address can be viewed by replacing `0` from above command with desired index.
 
 You can check the state of the nodes at any point by running the following command.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![tf-aws: Build and Test](https://github.com/yugabyte/terraform-aws-yugabyte/workflows/tf-aws:%20Build%20and%20Test/badge.svg)](https://github.com/yugabyte/terraform-aws-yugabyte/actions?query=workflow%3A%22tf-aws%3A+Build+and+Test%22)
+[![tf-aws: Update YugabyteDB version](https://github.com/yugabyte/terraform-aws-yugabyte/workflows/tf-aws:Update%20YugabyteDB%20version/badge.svg)](https://github.com/yugabyte/terraform-aws-yugabyte/actions?query=workflow%3A%22tf-aws%3A+Update+YugabyteDB+version%22)
+[![tf-aws: Update utilities submodule](https://github.com/yugabyte/terraform-aws-yugabyte/workflows/tf-aws:Update%20utilities%20submodule/badge.svg)](https://github.com/yugabyte/terraform-aws-yugabyte/actions?query=workflow%3A%22tf-aws%3A+Update+utilities+submodule%22)
+
 # terraform-aws-yugabyte
 A Terraform module to deploy and run YugabyteDB on Amazon Web Services (AWS).
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,60 +1,61 @@
 #########################################################
 #
-# Outputs for the YugaByte terraform module.
+# Outputs for the YugabyteDB Terraform module.
 #
 #########################################################
 
 output "master-ui" {
   sensitive = false
-  value     = "http://${aws_instance.yugabyte_nodes.*.public_ip[0]}:7000"
+  value     = "http://${aws_instance.yugabyte_nodes[0].public_ip}:7000"
 }
 
 output "tserver-ui" {
   sensitive = false
-  value     = "http://${aws_instance.yugabyte_nodes.*.public_ip[0]}:9000"
+  value     = "http://${aws_instance.yugabyte_nodes[0].public_ip}:9000"
 }
-
 
 output "public_ips" {
   sensitive = false
-  value     = "${aws_instance.yugabyte_nodes.*.public_ip}"
+  value     = aws_instance.yugabyte_nodes.*.public_ip
 }
 
 output "private_ips" {
   sensitive = false
-  value     = "${aws_instance.yugabyte_nodes.*.private_ip}"
+  value     = aws_instance.yugabyte_nodes.*.private_ip
 }
 
 output "security_group" {
   sensitive = false
-  value     = "${aws_security_group.yugabyte.id}"
+  value     = aws_security_group.yugabyte.id
 }
 
 output "ssh_user" {
   sensitive = false
-  value = "${var.ssh_user}"
+  value     = var.ssh_user
 }
+
 output "ssh_key" {
   sensitive = false
-  value     = "${var.ssh_private_key}"
+  value     = var.ssh_private_key
 }
 
 output "JDBC" {
-  sensitive =false
-  value     = "postgresql://yugabyte@${aws_instance.yugabyte_nodes.*.public_ip[0]}:5433"
+  sensitive = false
+  value     = "postgresql://yugabyte@${aws_instance.yugabyte_nodes[0].public_ip}:5433"
 }
 
-output "YSQL"{
+output "YSQL" {
   sensitive = false
-  value     = "ysqlsh -U yugabyte -h ${aws_instance.yugabyte_nodes.*.public_ip[0]} -p 5433"
+  value     = "ysqlsh -U yugabyte -h ${aws_instance.yugabyte_nodes[0].public_ip} -p 5433"
 }
 
-output "YCQL"{
+output "YCQL" {
   sensitive = false
-  value     = "ycqlsh ${aws_instance.yugabyte_nodes.*.public_ip[0]} 9042"
+  value     = "ycqlsh ${aws_instance.yugabyte_nodes[0].public_ip} 9042"
 }
 
-output "YEDIS"{
+output "YEDIS" {
   sensitive = false
-  value     = "redis-cli -h ${aws_instance.yugabyte_nodes.*.public_ip[0]} -p 6379"
- }
+  value     = "redis-cli -h ${aws_instance.yugabyte_nodes[0].public_ip} -p 6379"
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,124 +1,125 @@
-#########################################################
+##########################################################
 #
-# Default values for creating a YugaByte cluster on AWS.
+# Default values for creating a YugabyteDB cluster on AWS.
 #
-#########################################################
+##########################################################
 
 variable "associate_public_ip_address" {
   description = "Associate public IP address to instances created."
   default     = true
-  type        = "string"
+  type        = string
 }
 
 variable "cluster_name" {
   description = "The name for the cluster (universe) being created."
-  type        = "string"
+  type        = string
 }
 
 variable "custom_security_group_id" {
   description = "Security group to assign to the instances. Example: 'sg-12345'."
   default     = ""
-  type        = "string"
+  type        = string
 }
 
 variable "instance_type" {
   description = "The type of instances to create."
   default     = "c4.xlarge"
-  type        = "string"
+  type        = string
 }
 
 variable "num_instances" {
   description = "Number of instances in the YugaByte cluster."
   default     = "3"
-  type        = "string"
+  type        = string
 }
 
 variable "prefix" {
   description = "Prefix prepended to all resources created."
   default     = "yb-"
-  type        = "string"
+  type        = string
 }
 
 variable "replication_factor" {
   description = "The replication factor for the universe."
   default     = 3
-  type        = "string"
+  type        = string
 }
 
 variable "root_volume_iops" {
   description = "Provisioned IOPS - valid only for 'io1' type."
   default     = 0
-  type        = "string"
+  type        = string
 }
 
 variable "root_volume_size" {
   description = "The volume size in gigabytes."
   default     = "50"
-  type        = "string"
+  type        = string
 }
 
 variable "root_volume_type" {
   description = "The volume type. Must be one of 'gp2' or 'io1'."
   default     = "gp2"
-  type        = "string"
+  type        = string
 }
 
 variable "ssh_keypair" {
   description = "The SSH keypair name to use for the instances."
-  type        = "string"
+  type        = string
 }
 
 variable "ssh_private_key" {
   description = "The private key to use when connecting to the instances."
-  type        = "string"
+  type        = string
 }
 
 variable "ssh_user" {
   description = "The public key to use when connecting to the instances."
-  type        = "string"
+  type        = string
   default     = "centos"
 }
 
 variable "region_name" {
   description = "Region name for AWS. Example: 'us-west-2'"
-  type        = "string"
+  type        = string
 }
 
 variable "availability_zones" {
   description = "List of availability zones to utilize. Example: ['us-west-1a','us-west-1b','us-west-1c']"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "subnet_ids" {
   description = "List of subnets to launch the instances in. Example: ['subnet-12345','subnet-98765']."
-  type        = "list"
+  type        = list(string)
 }
 
 variable "use_public_ip_for_ssh" {
   description = "Flag to control use of public or private ips for ssh."
   default     = "true"
-  type        = "string"
+  type        = string
 }
 
 variable "vpc_id" {
   description = "The VPC ID to create the security groups in."
-  type        = "string"
+  type        = string
 }
 
 variable "yb_download_url" {
   description = "The download location of the YugaByteDB edition"
   default     = "https://downloads.yugabyte.com"
-  type        = "string"
+  type        = string
 }
 
 variable "yb_version" {
   description = "The version number of YugaByteDB to install"
   default     = "2.2.0.0"
-  type        = "string"
+  type        = string
 }
 
 variable "allowed_sources" {
   description = "Add Source IP in Security Group to restrict the traffic"
-  type        = "list"
+  type        = list(string)
   default     = ["0.0.0.0/0"]
 }
+


### PR DESCRIPTION
- Remove old interpolation syntax
  -   Few of the statements were already up to date according to Terraform 0.12, this change updates the remaining statements.
  -   Pin the aws provider version to 3.x.
  -   Run `terraform fmt`.
- Update the README, add workflow badges.

*The badges will start appearing correctly once all the renamed workflows run at least once.*

### Scenarios tested
- `terraform apply`, `init` work as expected.

Closes #22