### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Public IP
       id: ip
       run: |
-        echo ::set-output name=ipv4::$( curl https://checkip.amazonaws.com/ )
+        echo ipv4=$( curl https://checkip.amazonaws.com/ ) >> "$GITHUB_OUTPUT"
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -29,7 +29,7 @@ jobs:
           exit 1
         fi
         echo "Extracted the version number '${version_number}'."
-        echo "::set-output name=yb_version::${version_number}"
+        echo "yb_version=${version_number}" >> "$GITHUB_OUTPUT"
     - name: "Update the version"
       id: update-version
       continue-on-error: true


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter